### PR TITLE
Support Pico 2 RISC-V Hazard3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,6 @@ include(vendor/pico_sdk_import.cmake)
 add_subdirectory(vendor/pico-vfs)
 
 project(sqlite3 C CXX ASM)
-set(FAMILY rp2040)
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_CXX_STANDARD 17)
 

--- a/src/fallback.c
+++ b/src/fallback.c
@@ -8,6 +8,11 @@
 #include <pico/stdlib.h>
 #include "fallback.h"
 
+
+int access(const char *path, int mode) {
+    return 0;
+}
+
 int flock(int fd, int operation) {
     return 0;
 }


### PR DESCRIPTION
Fixed #5

Since the RISC-V execution environment does not include system call `access()`, add it as a fallback function.